### PR TITLE
Update GameServers when states are Allocated, Ready and Scheduled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ TESTS    := $(shell find internal cmd -name '*.go' -type f -not -name '*.pb.go' 
 
 BROADCASTER_BIN := bin/broadcaster-http
 
-DOCKER_IMAGE_TAG ?= octops/agones-broadcaster-http:v0.1.8-alpha
+DOCKER_IMAGE_TAG ?= octops/agones-broadcaster-http:v0.1.9-alpha
 
 default: clean build
 

--- a/install/install.yaml
+++ b/install/install.yaml
@@ -67,5 +67,5 @@ spec:
       serviceAccountName: agones-events-controller
       containers:
         - name: agones-events-controller
-          image: octops/agones-broadcaster-http:v0.1.8-alpha
+          image: octops/agones-broadcaster-http:v0.1.9-alpha
           imagePullPolicy: Always

--- a/pkg/broker/broker_http.go
+++ b/pkg/broker/broker_http.go
@@ -168,13 +168,18 @@ func (h *HTTPBroker) handleUpdated(message interface{}) error {
 	gsAgones := msgUpdate.Field(1).Interface().(*v1.GameServer)
 
 	gs := GameServer(gsAgones)
-	if gsAgones.Status.State == v1.GameServerStateReady {
+
+	switch gsAgones.Status.State {
+	case v1.GameServerStateReady:
 		return h.AddGameServer(gs)
+	case v1.GameServerStateAllocated:
+		return h.AddGameServer(gs)
+	case v1.GameServerStateScheduled:
+		return h.AddGameServer(gs)
+	default:
+		h.DeleteGameServer(gs.Namespaced())
+		return nil
 	}
-
-	h.DeleteGameServer(gs.Namespaced())
-
-	return nil
 }
 
 func (h *HTTPBroker) handleDeleted(gsAgones *v1.GameServer) error {

--- a/pkg/broker/broker_http.go
+++ b/pkg/broker/broker_http.go
@@ -170,11 +170,7 @@ func (h *HTTPBroker) handleUpdated(message interface{}) error {
 	gs := GameServer(gsAgones)
 
 	switch gsAgones.Status.State {
-	case v1.GameServerStateReady:
-		return h.AddGameServer(gs)
-	case v1.GameServerStateAllocated:
-		return h.AddGameServer(gs)
-	case v1.GameServerStateScheduled:
+	case v1.GameServerStateReady, v1.GameServerStateAllocated, v1.GameServerStateScheduled:
 		return h.AddGameServer(gs)
 	default:
 		h.DeleteGameServer(gs.Namespaced())


### PR DESCRIPTION
## What?
This PR updates the internal store when states are Allocated, Ready and Scheduled

## Why?
Previously only `Ready` gameservers would be updated, however some games may be in `Allocated` state and still accept new players to join the server, therefore still relevant to show them in the API response.

Example
```json
{
  "gameservers": [
    {
      "name": "godot-map1-deathmatch-vfn79-9zgxh",
      "namespace": "default",
      "labels": {
        "agones.dev/fleet": "godot-map1-deathmatch",
        "agones.dev/gameserverset": "godot-map1-deathmatch-vfn79",
        "map": "map_1",
        "mode": "deathmatch"
      },
      "addr": "172.19.0.2",
      "port": 7008,
      "state": "Ready",
      "node_name": "agones-broadcaster-http-control-plane",
      "players": {
        "capacity": 0,
        "count": 0
      }
    },
    {
      "name": "godot-map2-hidenseek-fkz9r-7t2zg",
      "namespace": "default",
      "labels": {
        "agones.dev/fleet": "godot-map2-hidenseek",
        "agones.dev/gameserverset": "godot-map2-hidenseek-fkz9r",
        "map": "map_2",
        "mode": "hidenseek"
      },
      "addr": "172.19.0.2",
      "port": 7000,
      "state": "Allocated",
      "node_name": "agones-broadcaster-http-control-plane",
      "players": {
        "capacity": 0,
        "count": 0
      }
    }
```